### PR TITLE
AppContainer binding: provide both a functor-based and a functor-less version

### DIFF
--- a/src/AppContainer.bs.js
+++ b/src/AppContainer.bs.js
@@ -1,11 +1,1 @@
-'use strict';
-
-var ReactNavigation = require("react-navigation");
-
-function Make(S) {
-  var make = ReactNavigation.createAppContainer(S[/* navigator */0]);
-  return /* module */[/* make */make];
-}
-
-exports.Make = Make;
-/* react-navigation Not a pure module */
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/src/AppContainer.re
+++ b/src/AppContainer.re
@@ -1,3 +1,17 @@
+// Low-level, zero-cost bindings to AppContainer.
+//
+// Usage:
+//
+// let appContainer = AppContainer.makeAppContainer(rootNavigator);
+//
+// React.createElement(
+//   appContainer,
+//   AppContainer.makeProps(
+//     ~screenProps, /* ... more props ... */
+//     (),
+//   ),
+// );
+
 type persistNavigationState = NavigationState.t => Js.Promise.t(unit);
 type loadNavigationState = unit => Js.Promise.t(option(NavigationState.t));
 
@@ -9,27 +23,20 @@ type appContainerProps('screenProps) = {
   "setNavigatorRef": Js.Nullable.t(NavigationContainer.t) => unit,
 };
 
-module Make = (S: {
-                 type screenProps;
-                 let navigator: Navigator.t;
-               }) => {
-  [@bs.module "react-navigation"]
-  external make:
-    Navigator.t => React.component(appContainerProps(S.screenProps)) =
-    "createAppContainer";
+[@bs.obj]
+external makeProps:
+  (
+    ~persistNavigationState: persistNavigationState=?,
+    ~loadNavigationState: loadNavigationState=?,
+    ~screenProps: 'screenProps=?,
+    ~setNavigatorRef: Js.Nullable.t(NavigationContainer.t) => unit=?,
+    ~key: string=?,
+    unit
+  ) =>
+  appContainerProps('screenProps) =
+  "";
 
-  [@bs.obj]
-  external makeProps:
-    (
-      ~persistNavigationState: persistNavigationState=?,
-      ~loadNavigationState: loadNavigationState=?,
-      ~screenProps: S.screenProps=?,
-      ~setNavigatorRef: Js.Nullable.t(NavigationContainer.t) => unit=?,
-      ~key: string=?,
-      unit
-    ) =>
-    appContainerProps(S.screenProps) =
-    "";
-
-  let make = make(S.navigator);
-};
+[@bs.module "react-navigation"]
+external makeAppContainer:
+  Navigator.t => React.component(appContainerProps('screenProps)) =
+  "createAppContainer";

--- a/src/AppContainerFunctor.bs.js
+++ b/src/AppContainerFunctor.bs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var ReactNavigation = require("react-navigation");
+
+function Make(S) {
+  var make = ReactNavigation.createAppContainer(S[/* navigator */0]);
+  return /* module */[/* make */make];
+}
+
+exports.Make = Make;
+/* react-navigation Not a pure module */

--- a/src/AppContainerFunctor.re
+++ b/src/AppContainerFunctor.re
@@ -1,0 +1,37 @@
+// High-level, non-zero-cost bindings to AppContainer.
+//
+// Usage:
+//
+// module MyAppContainer =
+//   AppContainer.Make({
+//     type screenProps = /* my screen props type */;
+//     let navigator = /* my root navigator component */;
+//   });
+//
+// <MyAppContainer screenProps /* ... more props ... */ />
+
+module Make = (S: {
+                 type screenProps;
+                 let navigator: Navigator.t;
+               }) => {
+  [@bs.module "react-navigation"]
+  external make:
+    Navigator.t =>
+    React.component(AppContainer.appContainerProps(S.screenProps)) =
+    "createAppContainer";
+
+  [@bs.obj]
+  external makeProps:
+    (
+      ~persistNavigationState: AppContainer.persistNavigationState=?,
+      ~loadNavigationState: AppContainer.loadNavigationState=?,
+      ~screenProps: S.screenProps=?,
+      ~setNavigatorRef: Js.Nullable.t(NavigationContainer.t) => unit=?,
+      ~key: string=?,
+      unit
+    ) =>
+    AppContainer.appContainerProps(S.screenProps) =
+    "";
+
+  let make = make(S.navigator);
+};


### PR DESCRIPTION
* The functor-based version should be easier to use for beginners as it gives you a normal ReasonReact component (module). But it is not zero-cost.
* The non-functor-based version is zero-cost, but you need to do `React.createElement(...)` yourself. It allows advanced use cases such as (re)creating your AppContainer based e.g. on permission changes.